### PR TITLE
Clarify sandbox reuse API levels in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,9 @@ sandbox = await manager.create_sandbox(
 )
 ```
 
-### Smart Sandbox Reuse
+### Sandbox Reuse (Provider-Level)
+
+For advanced control, work directly with providers instead of the high-level `Sandbox` API:
 
 ```python
 # Sandboxes can be reused based on labels


### PR DESCRIPTION
Distinguish between high-level Sandbox.get_or_create() and provider-level get_or_create_sandbox()/find_sandbox() to reduce confusion.