### PR TITLE
Improve shell compatibility and update CLI defaults

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Cased
+Copyright (c) 2025 Cased
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ async def main():
 asyncio.run(main())
 
 # Via CLI
-# sandboxes run "python --version" --image python:3.12-alpine
+# sandboxes run "python --version" --image python:3.12-slim
 ```
 
 ## API Reference

--- a/benchmarks/image_reuse.py
+++ b/benchmarks/image_reuse.py
@@ -198,7 +198,7 @@ async def test_provider_image_patterns(provider_class, provider_name: str):
             test_images = [
                 "python:3.11-slim",
                 "python:3.12-slim",
-                "python:3.10-alpine",
+                "python:3.10-slim",
                 "ubuntu:22.04",
             ]
         elif provider_name == "E2B":

--- a/sandboxes/cli.py
+++ b/sandboxes/cli.py
@@ -48,7 +48,7 @@ def cli():
 @click.argument("command", required=False)
 @click.option("--file", "-f", type=click.Path(exists=True), help="Execute code from a file")
 @click.option("--language", "--lang", help="Language/runtime (python, node, go, etc.)")
-@click.option("--provider", "-p", default="modal", help="Provider to use (e2b, modal, daytona)")
+@click.option("--provider", "-p", default="daytona", help="Provider to use (daytona, e2b, modal)")
 @click.option("--image", "-i", help="Docker image or template")
 @click.option("--env", "-e", multiple=True, help="Environment variables (KEY=VALUE)")
 @click.option("--label", "-l", multiple=True, help="Labels (KEY=VALUE)")

--- a/sandboxes/providers/modal.py
+++ b/sandboxes/providers/modal.py
@@ -265,9 +265,10 @@ class ModalProvider(SandboxProvider):
             start_time = time.time()
 
             # Modal's exec returns a process object
+            # Use 'sh' instead of 'bash' for alpine compatibility
             process = await loop.run_in_executor(
                 self._executor,
-                lambda: modal_sandbox.exec("bash", "-c", command, timeout=timeout or self.timeout),
+                lambda: modal_sandbox.exec("sh", "-c", command, timeout=timeout or self.timeout),
             )
 
             # Get output


### PR DESCRIPTION
Alpine images don't have bash, only sh. Using sh -c works on all Linux images (Alpine, Debian, Ubuntu, etc.), and is a better default here.